### PR TITLE
Ci/fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ matrix:
   include:
       # works on Precise and Trusty
       - os: linux
+        addons:
+          apt:
+            sources:
+              - ubuntu-toolchain-r-test
+            packages:
+              - g++-4.8
         env:
            - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ sudo: required
 matrix:
   include:
       # works on Precise and Trusty
-      - os: linux
-        addons:
-          apt:
-            sources:
-              - ubuntu-toolchain-r-test
-            packages:
-              - g++-4.8
-        env:
-           - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.8
+      env:
+        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
 
     # works on Precise and Trusty
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ matrix:
          - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
 
 before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y valgrind
   - wget https://cmake.org/files/v3.5/cmake-3.5.1-Linux-x86_64.sh
   - sudo sh cmake-3.5.1-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
   - eval "${MATRIX_EVAL}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ matrix:
   include:
       # works on Precise and Trusty
     - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.8
       env:
         - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ sudo: required
 
 matrix:
   include:
+      # works on Precise and Trusty
+      - os: linux
+        env:
+           - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
+
     # works on Precise and Trusty
     - os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,36 @@
 language: cpp
 
+dist: trusty
 sudo: required
 
+matrix:
+  include:
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
 before_install:
-  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - sudo apt-get update
-  - sudo apt-get -y install docker-ce
-install:
-  - docker build -t helloworldcpp .
+  - wget https://cmake.org/files/v3.5/cmake-3.5.1-Linux-x86_64.sh
+  - sudo sh cmake-3.5.1-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
+  - eval "${MATRIX_EVAL}"
+
 script:
-  - docker run helloworldcpp:latest
+  - ./install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,41 +3,11 @@ language: cpp
 dist: trusty
 sudo: required
 
-matrix:
-  include:
-      # works on Precise and Trusty
-    - os: linux
-      env:
-        - MATRIX_EVAL="CC=gcc-4.8 && CXX=g++-4.8"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
-
-    # works on Precise and Trusty
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-         - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
-
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y valgrind
   - wget https://cmake.org/files/v3.5/cmake-3.5.1-Linux-x86_64.sh
   - sudo sh cmake-3.5.1-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir
-  - eval "${MATRIX_EVAL}"
 
 script:
   - ./install.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 
-RUN apt update
+RUN apt update -qq
 RUN apt install -y \
     build-essential \
     wget \

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,6 @@ valgrind --leak-check=full\
          --show-leak-kinds=all\
          --trace-children=yes\
          --error-exitcode=1 --errors-for-leak-kinds=all ./tests
-echo "Valgrind exit code" $?
-echo "==================== Done ===================="
-exit $?
+#echo "Valgrind exit code" $?
+#echo "==================== Done ===================="
+#exit $?

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,3 @@ valgrind --leak-check=full\
          --show-leak-kinds=all\
          --trace-children=yes\
          --error-exitcode=1 --errors-for-leak-kinds=all ./tests
-#echo "Valgrind exit code" $?
-#echo "==================== Done ===================="
-#exit $?


### PR DESCRIPTION
- Travis ya no usa mas Docker para correr el proyecto.
- Los codigos de error se capturan correctamente cuando termina el build.
- Si revisas los commits podes ver que se probo de usar versiones de gcc mas nuevas (4.8.5, 4.9, 5.4).  Al final las descarte porque introducen leaks que no son de nuestro codigo. El unico inconveniente de dejar gcc < 4.9 es que no tiene soporte de regex (el resto de C++11 lo soporta perfectamente) pero como no creo que vayamos a usarlo no vamos a tener problema.